### PR TITLE
[operator] retry stream reconciliation and fix stale session tracking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/r3labs/sse/v2 v2.10.0
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/image v0.24.0
+	golang.org/x/time v0.7.0
 	k8s.io/api v0.33.0-alpha.3
 	k8s.io/apimachinery v0.33.0-alpha.3
 	k8s.io/client-go v0.33.0-alpha.3
@@ -17,6 +17,7 @@ require (
 	sigs.k8s.io/controller-tools v0.17.2
 	sigs.k8s.io/gateway-api v1.2.1
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -55,7 +56,6 @@ require (
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/term v0.29.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
-	golang.org/x/time v0.7.0 // indirect
 	golang.org/x/tools v0.29.0 // indirect
 	google.golang.org/protobuf v1.36.1 // indirect
 	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
@@ -67,5 +67,4 @@ require (
 	k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7 // indirect
 	k8s.io/kube-openapi v0.0.0-20241212222426-2c72e554b1e7 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,6 @@ github.com/onsi/ginkgo/v2 v2.22.1 h1:QW7tbJAUDyVDVOM5dFa7qaybo+CRfR7bemlQUN6Z8aM
 github.com/onsi/ginkgo/v2 v2.22.1/go.mod h1:S6aTpoRsSq2cZOd+pssHAlKW/Q/jZt6cPrPlnj4a1xM=
 github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
 github.com/onsi/gomega v1.36.2/go.mod h1:DdwyADRjrc825LhMEkD76cHR5+pUnjhUN8GlHlRPHzY=
-github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
-github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/controllers/session.go
+++ b/pkg/controllers/session.go
@@ -256,6 +256,12 @@ func (c *SessionController) Reconcile(namespace, name string, newObj *v1alpha1ty
 	} else {
 		c.trackedSessions[ug] = sets.New(newObj.Name)
 	}
+	// Record the reverse mapping too: the deletion branch above relies on
+	// trackedGames to clean trackedSessions up. Without this, sessions created
+	// after startup are never removed from trackedSessions and every later
+	// reconcile of the same user/game spams "Failed to get session ... not
+	// found" while iterating the stale names.
+	c.trackedGames[newObj.Name] = ug
 
 	oldStatus := newObj.Status.DeepCopy()
 	portsError := c.allocatePorts(context.TODO(), newObj)
@@ -358,7 +364,8 @@ func (c *SessionController) Reconcile(namespace, name string, newObj *v1alpha1ty
 	// 	})
 	// }
 
-	if streamError := c.reconcileActiveStreams(context.TODO(), newObj); streamError != nil {
+	streamError := c.reconcileActiveStreams(context.TODO(), newObj)
+	if streamError != nil {
 		klog.Errorf("Failed to reconcile active streams: %s", streamError)
 		meta.SetStatusCondition(&newObj.Status.Conditions, metav1.Condition{
 			Type:    "StreamStarted",
@@ -392,8 +399,15 @@ func (c *SessionController) Reconcile(namespace, name string, newObj *v1alpha1ty
 		}
 	}
 
-	//!TODO: figure our retry logic. Some of these errors surely are retriable
-	return nil
+	// Stream setup is inherently retriable: while the pod is starting up the
+	// deployment isn't ready and wolf-agent isn't listening yet ("connection
+	// refused"), and no informer event is guaranteed to arrive once it
+	// becomes ready. Returning nil here used to stall the session as soon as
+	// the status stopped changing, until the 1-minute dead-session reaper
+	// deleted it and Moonlight timed out. Return the error so the workqueue
+	// requeues with backoff and the stream is started as soon as the agent
+	// is reachable.
+	return streamError
 }
 
 // // !TODO: Unused. Part of testing gateway implementation. The final idea is for
@@ -708,6 +722,14 @@ func (c *SessionController) reconcilePod(ctx context.Context, session *v1alpha1t
 		for name := range sessions {
 			sess, err := c.SessionInformer.Namespaced(session.Namespace).Get(name)
 			if err != nil {
+				if errors.IsNotFound(err) {
+					// Stale entry left behind by an earlier missed cleanup:
+					// the Session object is gone, so drop it from tracking
+					// instead of logging an error forever.
+					sessions.Delete(name)
+					delete(c.trackedGames, name)
+					continue
+				}
 				klog.Errorf("Failed to get session %s/%s: %s", session.Namespace, name, err)
 				continue
 			}

--- a/pkg/generic/controller.go
+++ b/pkg/generic/controller.go
@@ -24,6 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/time/rate"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -106,8 +107,15 @@ func (c *controller[T]) Run(ctx context.Context) error {
 	klog.Infof("starting %s", c.options.Name)
 	defer klog.Infof("stopping %s", c.options.Name)
 
+	// Same shape as workqueue.DefaultTypedControllerRateLimiter, but with the
+	// per-item exponential backoff capped at 5s instead of 1000s. Sessions
+	// only live for ~1 minute before the dead-session reaper collects them,
+	// so retries (e.g. waiting for wolf-agent to come up) must stay frequent.
 	c.queue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.DefaultTypedControllerRateLimiter[string](),
+		workqueue.NewTypedMaxOfRateLimiter(
+			workqueue.NewTypedItemExponentialFailureRateLimiter[string](5*time.Millisecond, 5*time.Second),
+			&workqueue.TypedBucketRateLimiter[string]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+		),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: c.options.Name},
 	)
 


### PR DESCRIPTION
## Problem

The session controller has two issues that surface as stalled sessions and endless log spam when running under Kubernetes.

**1. Stream reconciliation is never retried.** `Reconcile` calls `reconcileActiveStreams` but discards the result and returns `nil`:

```go
if streamError := c.reconcileActiveStreams(context.TODO(), newObj); streamError != nil {
    klog.Errorf("Failed to reconcile active streams: %s", streamError)
    // ... sets a status condition, but falls through ...
}

//!TODO: figure our retry logic. Some of these errors surely are retriable
return nil
```

During pod startup the session Deployment isn't ready and `wolf-agent` isn't listening yet, so `reconcileActiveStreams` fails with `connection refused` / "deployment not ready". Because the error is swallowed and no further informer event is guaranteed once the agent does come up, the stream is never started. The session sits idle until the 1-minute dead-session reaper deletes it, and Moonlight times out.

**2. `trackedSessions` is never cleaned up for sessions created after startup.** `Reconcile` inserts into `trackedSessions`, but only the startup path records the reverse `trackedGames` mapping that the deletion branch relies on. So sessions created at runtime are never removed from tracking, and every later reconcile of the same user/game iterates the stale names and logs:

```
Failed to get session <namespace>/<name>: ... not found
```

forever.

## Fix

* Return the stream error from `Reconcile` so the workqueue requeues with backoff and the stream is started as soon as `wolf-agent` becomes reachable.
* Cap the per-item exponential backoff at **5s** (custom rate limiter — same shape as `workqueue.DefaultTypedControllerRateLimiter`, but with the per-item max lowered from 1000s to 5s). Sessions only live ~1 minute before the reaper collects them, so retries must stay frequent to be useful.
* Record the reverse `trackedGames` mapping on every reconcile (not just at startup), and defensively prune `NotFound` entries while building owner references so stale names self-heal instead of logging forever.

## Testing

* `go build ./...` (native and `GOOS=linux GOARCH=amd64`) and `go test ./pkg/generic/...` pass.
* Running on my Talos cluster (NVIDIA RTX 5090, fenrir/wolf) since June 10: sessions now recover from the "agent not ready yet" startup race instead of stalling until the reaper kills them. Engineering notes / full context: https://github.com/shrinedogg/biggs.dog#patched-fork--engineering-notes
