### PR TITLE
[moonlight-proxy] raise launch wait from 25s to 120s

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ In response to `/launch` or `/resume` from Moonlight client launching an app,
 and `Pairing` for the specific client used. It then waits for the `Session`
 to have an `rtsp` URL added to its status by the `operator` to hand back to the uses.
 
+### Configuration
+
+`moonlight-proxy` is configured via command-line flags:
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--port` | `47989` | HTTP port to listen on. |
+| `--secure-port` | `47984` | HTTPS port to listen on. |
+| `--tls-cert` | `server.crt` | Path to the server TLS certificate. |
+| `--tls-key` | `server.key` | Path to the server TLS key. |
+| `--namespace` | `$POD_NAMESPACE` | Namespace to watch for CRDs. |
+| `--launch-timeout` | `60s` | How long `/launch` waits for the operator to create a session and expose its stream URL before giving up. The wait is still bounded by the client connection, so a disconnecting Moonlight client cancels it early. Raise this if cold starts (image pull + wolf boot + `wolf-agent` readiness) are getting cancelled with an HTTP 500; lower it to fail faster. |
+
 ## wolf-agent
 
 Wolf-Agent is a sidecar container with Wolf's HTTP API socket mounted locally.
@@ -181,5 +194,4 @@ open moonlight to pair with the acquired ip
 then get the moonlight-proxy pairing url through the logs:  
 `kubectl logs -n direwolf deployments/direwolf-moonlight-proxy`
 
-use it to pair and then connect with the app, it'll take a moment to pull the image, so the first pairing might fail.  
-
+use it to pair and then connect with the app, it'll take a moment to pull the image, so the first pairing might fail.

--- a/cmd/moonlight-proxy/main.go
+++ b/cmd/moonlight-proxy/main.go
@@ -25,6 +25,7 @@ func main() {
 	serverKeyPath := flag.String("tls-key", "server.key", "Path to server key")
 	port := flag.Int("port", 47989, "Port to listen on")
 	securePort := flag.Int("secure-port", 47984, "Secure port to listen on")
+	launchTimeout := flag.Duration("launch-timeout", 60*time.Second, "How long to wait for a session to become ready when launching an app (cold starts may need more time)")
 	namespace := flag.String("namespace", os.Getenv("POD_NAMESPACE"), "Namespace to watch")
 	klog.InitFlags(nil)
 	flag.Parse()
@@ -34,6 +35,7 @@ func main() {
 	klog.Info("TLS Key: ", *serverKeyPath)
 	klog.Info("Port: ", *port)
 	klog.Info("Secure Port: ", *securePort)
+	klog.Info("Launch timeout: ", *launchTimeout)
 	klog.Info("Namespace: ", *namespace)
 
 	tlsCert, err := util.LoadCertificates(*serverCertPath, *serverKeyPath)
@@ -83,9 +85,10 @@ func main() {
 		generic.NewLister[*v1.Pod](podInformer.GetIndexer()).Namespaced(*namespace),
 		direwolfClient.DirewolfV1alpha1().Sessions(*namespace),
 		moonlight.RESTServerOptions{
-			Port:       *port,
-			SecurePort: *securePort,
-			Cert:       tlsCert,
+			Port:          *port,
+			SecurePort:    *securePort,
+			Cert:          tlsCert,
+			LaunchTimeout: *launchTimeout,
 		},
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,10 @@ go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/r3labs/sse/v2 v2.10.0
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/image v0.24.0
+	golang.org/x/time v0.7.0
 	k8s.io/api v0.33.0-alpha.3
 	k8s.io/apimachinery v0.33.0-alpha.3
 	k8s.io/client-go v0.33.0-alpha.3
@@ -17,6 +17,7 @@ require (
 	sigs.k8s.io/controller-tools v0.17.2
 	sigs.k8s.io/gateway-api v1.2.1
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -55,7 +56,6 @@ require (
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/term v0.29.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
-	golang.org/x/time v0.7.0 // indirect
 	golang.org/x/tools v0.29.0 // indirect
 	google.golang.org/protobuf v1.36.1 // indirect
 	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
@@ -67,5 +67,4 @@ require (
 	k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7 // indirect
 	k8s.io/kube-openapi v0.0.0-20241212222426-2c72e554b1e7 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,6 @@ github.com/onsi/ginkgo/v2 v2.22.1 h1:QW7tbJAUDyVDVOM5dFa7qaybo+CRfR7bemlQUN6Z8aM
 github.com/onsi/ginkgo/v2 v2.22.1/go.mod h1:S6aTpoRsSq2cZOd+pssHAlKW/Q/jZt6cPrPlnj4a1xM=
 github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
 github.com/onsi/gomega v1.36.2/go.mod h1:DdwyADRjrc825LhMEkD76cHR5+pUnjhUN8GlHlRPHzY=
-github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
-github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/api/v1alpha1/app.go
+++ b/pkg/api/v1alpha1/app.go
@@ -64,7 +64,7 @@ type RuntimeWolfVariables struct {
 	// Wolf defaults to: "/dev/dri/renderD128"
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="/dev/dri/renderD128"
-	RenderNode string `json:"renderNode,omitempty""`
+	RenderNode string `json:"renderNode,omitempty"`
 	
 	// Time zone for the wolf container
 	// +kubebuilder:validation:Optional

--- a/pkg/controllers/agent.go
+++ b/pkg/controllers/agent.go
@@ -5,10 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"games-on-whales.github.io/direwolf/pkg/fakeudev"
 	"games-on-whales.github.io/direwolf/pkg/wolfapi"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
 )
+
+// UdevDataPath is where udev database entries are written for hotplugged
+// devices. It must be a volume shared with the app container (mounted at
+// /run/udev there) for libudev consumers (SDL/Steam) to see them.
+const UdevDataPath = "/run/udev/data"
 
 // Represents the controller that runs inside the Pod itself
 type Agent struct {
@@ -73,6 +79,24 @@ func (a *Agent) watchEvents(ctx context.Context) error {
 						utilruntime.HandleError(fmt.Errorf("failed to stop session: %w", err))
 						continue
 					}
+				// Wolf hotplugged a virtual input device. Play the role of
+				// fake-udev: publish the udev db entry and broadcast a
+				// synthetic udev netlink event in the pod's network
+				// namespace so the app container's SDL/Steam notices it.
+				case wolfapi.PlugDeviceEventType:
+					var plugEvent wolfapi.PlugDeviceEvent
+					if err := json.Unmarshal(ev.Data, &plugEvent); err != nil {
+						utilruntime.HandleError(fmt.Errorf("failed to unmarshal plug device event: %w", err))
+						continue
+					}
+					a.handleDevicePlug(plugEvent)
+				case wolfapi.UnplugDeviceEventType:
+					var unplugEvent wolfapi.UnplugDeviceEvent
+					if err := json.Unmarshal(ev.Data, &unplugEvent); err != nil {
+						utilruntime.HandleError(fmt.Errorf("failed to unmarshal unplug device event: %w", err))
+						continue
+					}
+					a.handleDeviceUnplug(unplugEvent)
 				default:
 					continue
 				}
@@ -81,4 +105,64 @@ func (a *Agent) watchEvents(ctx context.Context) error {
 	}()
 
 	return nil
+}
+
+func (a *Agent) handleDevicePlug(ev wolfapi.PlugDeviceEvent) {
+	// Wolf reports MAJOR/MINOR as "0" when it cannot stat the device node
+	// in its own container; resolve the real numbers from sysfs so both
+	// the netlink event and the hwdb filename are correct.
+	for _, udevEvent := range ev.UdevEvents {
+		fakeudev.ResolveDevNumbers(udevEvent)
+	}
+
+	for _, entry := range ev.UdevHwDbEntries {
+		filename := entry.Filename
+		// Recompute "cMAJOR:MINOR" filenames that were built from the
+		// zeroed-out device numbers.
+		if filename == "c0:0" && len(ev.UdevEvents) > 0 {
+			if maj := ev.UdevEvents[0]["MAJOR"]; maj != "" && maj != "0" {
+				filename = "c" + maj + ":" + ev.UdevEvents[0]["MINOR"]
+			}
+		}
+		if err := fakeudev.WriteHwDbEntry(UdevDataPath, filename, entry.Content); err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to write udev hwdb entry %q: %w", filename, err))
+		} else {
+			klog.InfoS("Wrote udev hwdb entry", "file", filename, "session", ev.SessionID)
+		}
+	}
+
+	for _, udevEvent := range ev.UdevEvents {
+		if err := fakeudev.SendEvent(udevEvent); err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to send udev event for %q: %w", udevEvent["DEVNAME"], err))
+		} else {
+			klog.InfoS("Sent fake udev event", "action", udevEvent["ACTION"], "devname", udevEvent["DEVNAME"], "session", ev.SessionID)
+		}
+	}
+}
+
+func (a *Agent) handleDeviceUnplug(ev wolfapi.UnplugDeviceEvent) {
+	for _, udevEvent := range ev.UdevEvents {
+		fakeudev.ResolveDevNumbers(udevEvent)
+	}
+
+	for _, entry := range ev.UdevHwDbEntries {
+		filename := entry.Filename
+		if filename == "c0:0" && len(ev.UdevEvents) > 0 {
+			if maj := ev.UdevEvents[0]["MAJOR"]; maj != "" && maj != "0" {
+				filename = "c" + maj + ":" + ev.UdevEvents[0]["MINOR"]
+			}
+		}
+		if err := fakeudev.RemoveHwDbEntry(UdevDataPath, filename); err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to remove udev hwdb entry %q: %w", filename, err))
+		}
+	}
+
+	for _, udevEvent := range ev.UdevEvents {
+		udevEvent["ACTION"] = "remove"
+		if err := fakeudev.SendEvent(udevEvent); err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to send udev remove event for %q: %w", udevEvent["DEVNAME"], err))
+		} else {
+			klog.InfoS("Sent fake udev remove event", "devname", udevEvent["DEVNAME"], "session", ev.SessionID)
+		}
+	}
 }

--- a/pkg/controllers/session.go
+++ b/pkg/controllers/session.go
@@ -256,6 +256,12 @@ func (c *SessionController) Reconcile(namespace, name string, newObj *v1alpha1ty
 	} else {
 		c.trackedSessions[ug] = sets.New(newObj.Name)
 	}
+	// Record the reverse mapping too: the deletion branch above relies on
+	// trackedGames to clean trackedSessions up. Without this, sessions created
+	// after startup are never removed from trackedSessions and every later
+	// reconcile of the same user/game spams "Failed to get session ... not
+	// found" while iterating the stale names.
+	c.trackedGames[newObj.Name] = ug
 
 	oldStatus := newObj.Status.DeepCopy()
 	portsError := c.allocatePorts(context.TODO(), newObj)
@@ -358,7 +364,8 @@ func (c *SessionController) Reconcile(namespace, name string, newObj *v1alpha1ty
 	// 	})
 	// }
 
-	if streamError := c.reconcileActiveStreams(context.TODO(), newObj); streamError != nil {
+	streamError := c.reconcileActiveStreams(context.TODO(), newObj)
+	if streamError != nil {
 		klog.Errorf("Failed to reconcile active streams: %s", streamError)
 		meta.SetStatusCondition(&newObj.Status.Conditions, metav1.Condition{
 			Type:    "StreamStarted",
@@ -392,8 +399,15 @@ func (c *SessionController) Reconcile(namespace, name string, newObj *v1alpha1ty
 		}
 	}
 
-	//!TODO: figure our retry logic. Some of these errors surely are retriable
-	return nil
+	// Stream setup is inherently retriable: while the pod is starting up the
+	// deployment isn't ready and wolf-agent isn't listening yet ("connection
+	// refused"), and no informer event is guaranteed to arrive once it
+	// becomes ready. Returning nil here used to stall the session as soon as
+	// the status stopped changing, until the 1-minute dead-session reaper
+	// deleted it and Moonlight timed out. Return the error so the workqueue
+	// requeues with backoff and the stream is started as soon as the agent
+	// is reachable.
+	return streamError
 }
 
 // // !TODO: Unused. Part of testing gateway implementation. The final idea is for
@@ -708,6 +722,14 @@ func (c *SessionController) reconcilePod(ctx context.Context, session *v1alpha1t
 		for name := range sessions {
 			sess, err := c.SessionInformer.Namespaced(session.Namespace).Get(name)
 			if err != nil {
+				if errors.IsNotFound(err) {
+					// Stale entry left behind by an earlier missed cleanup:
+					// the Session object is gone, so drop it from tracking
+					// instead of logging an error forever.
+					sessions.Delete(name)
+					delete(c.trackedGames, name)
+					continue
+				}
 				klog.Errorf("Failed to get session %s/%s: %s", session.Namespace, name, err)
 				continue
 			}

--- a/pkg/fakeudev/fakeudev.go
+++ b/pkg/fakeudev/fakeudev.go
@@ -1,0 +1,173 @@
+// Package fakeudev replicates wolf's fake-udev mechanism in Go.
+//
+// Wolf creates virtual input devices (joypads, mice, keyboards) through
+// /dev/uinput. The kernel emits the corresponding uevents only in the
+// initial network namespace, so processes inside the session pod never
+// hear about them, and libudev consumers (SDL, Steam) ignore devices
+// that have no entry in the udev database (/run/udev/data).
+//
+// In wolf's Docker runner this is solved by exec'ing the `fake-udev` C
+// binary inside the app container, which:
+//  1. writes the udev hwdb entries under /run/udev/data, and
+//  2. broadcasts a synthetic "libudev" netlink message to the udev
+//     multicast group (2) inside the container's network namespace.
+//
+// Containers in a Kubernetes pod share their network namespace, so the
+// wolf-agent sidecar can do both jobs for the app container, provided
+// /run/udev is a volume shared between the agent and app containers.
+//
+// Wire format reference:
+// https://github.com/systemd/systemd/blob/main/src/libsystemd/sd-device/device-monitor.c
+// and wolf's src/fake-udev.
+package fakeudev
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	udevMonitorMagic = 0xfeedcafe
+	// Multicast group used by udevd -> libudev listeners ("udev" source).
+	udevEventGroup = 2
+)
+
+// murmurHash2 is the classic (non-A) MurmurHash2 used by
+// systemd/libudev for filter_subsystem_hash (util_string_hash32).
+func murmurHash2(data []byte, seed uint32) uint32 {
+	const m = 0x5bd1e995
+	const r = 24
+
+	h := seed ^ uint32(len(data))
+	for len(data) >= 4 {
+		k := binary.LittleEndian.Uint32(data)
+		k *= m
+		k ^= k >> r
+		k *= m
+		h *= m
+		h ^= k
+		data = data[4:]
+	}
+	switch len(data) {
+	case 3:
+		h ^= uint32(data[2]) << 16
+		fallthrough
+	case 2:
+		h ^= uint32(data[1]) << 8
+		fallthrough
+	case 1:
+		h ^= uint32(data[0])
+		h *= m
+	}
+	h ^= h >> 13
+	h *= m
+	h ^= h >> 15
+	return h
+}
+
+// header mirrors systemd's monitor_netlink_header (40 bytes).
+func makeHeader(propertiesLen int, subsystem, devtype string) []byte {
+	buf := &bytes.Buffer{}
+	buf.WriteString("libudev")
+	buf.WriteByte(0)
+	// magic is stored in network byte order
+	_ = binary.Write(buf, binary.BigEndian, uint32(udevMonitorMagic))
+	// sizes/offsets are native endian (x86_64: little endian)
+	_ = binary.Write(buf, binary.LittleEndian, uint32(40)) // header_size
+	_ = binary.Write(buf, binary.LittleEndian, uint32(40)) // properties_off
+	_ = binary.Write(buf, binary.LittleEndian, uint32(propertiesLen))
+	var subsystemHash, devtypeHash uint32
+	if subsystem != "" {
+		subsystemHash = murmurHash2([]byte(subsystem), 0)
+	}
+	if devtype != "" {
+		devtypeHash = murmurHash2([]byte(devtype), 0)
+	}
+	// filter hashes are stored in network byte order
+	_ = binary.Write(buf, binary.BigEndian, subsystemHash)
+	_ = binary.Write(buf, binary.BigEndian, devtypeHash)
+	_ = binary.Write(buf, binary.LittleEndian, uint32(0)) // filter_tag_bloom_hi
+	_ = binary.Write(buf, binary.LittleEndian, uint32(0)) // filter_tag_bloom_lo
+	return buf.Bytes()
+}
+
+// encodeProperties serializes the udev properties as NUL-separated
+// KEY=VALUE pairs, ACTION first (mirrors wolf's std::map ordering, which
+// is alphabetical; ACTION happens to sort first anyway).
+func encodeProperties(props map[string]string) []byte {
+	keys := make([]string, 0, len(props))
+	for k := range props {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	buf := &bytes.Buffer{}
+	for _, k := range keys {
+		buf.WriteString(k)
+		buf.WriteByte('=')
+		buf.WriteString(props[k])
+		buf.WriteByte(0)
+	}
+	return buf.Bytes()
+}
+
+// SendEvent broadcasts a synthetic libudev netlink event in the current
+// network namespace. Requires CAP_NET_ADMIN. See fakeudev_linux.go.
+func SendEvent(props map[string]string) error {
+	subsystem := props["SUBSYSTEM"]
+	if subsystem == "" {
+		subsystem = "input"
+	}
+	payload := encodeProperties(props)
+	msg := append(makeHeader(len(payload), subsystem, props["DEVTYPE"]), payload...)
+	return sendNetlink(msg)
+}
+
+// WriteHwDbEntry writes a udev database entry (e.g. "c13:67") under
+// baseDir (normally /run/udev/data) so libudev enumeration picks up the
+// device properties (ID_INPUT_JOYSTICK etc.).
+func WriteHwDbEntry(baseDir, filename string, content []string) error {
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		return err
+	}
+	path := filepath.Join(baseDir, filepath.Base(filename))
+	return os.WriteFile(path, []byte(strings.Join(content, "\n")), 0o644)
+}
+
+// RemoveHwDbEntry deletes a previously written udev database entry.
+func RemoveHwDbEntry(baseDir, filename string) error {
+	err := os.Remove(filepath.Join(baseDir, filepath.Base(filename)))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// ResolveDevNumbers fills in MAJOR/MINOR from sysfs when wolf could not
+// stat the device node itself (it reports "0"/"0" in that case, because
+// /dev/input is not mounted in the wolf container). DEVPATH is always
+// present and sysfs is readable from any container.
+func ResolveDevNumbers(props map[string]string) (major, minor string) {
+	major, minor = props["MAJOR"], props["MINOR"]
+	if major != "" && major != "0" {
+		return major, minor
+	}
+	devpath := props["DEVPATH"]
+	if devpath == "" {
+		return major, minor
+	}
+	data, err := os.ReadFile(filepath.Join("/sys", devpath, "dev"))
+	if err != nil {
+		return major, minor
+	}
+	parts := strings.SplitN(strings.TrimSpace(string(data)), ":", 2)
+	if len(parts) != 2 {
+		return major, minor
+	}
+	props["MAJOR"], props["MINOR"] = parts[0], parts[1]
+	return parts[0], parts[1]
+}

--- a/pkg/fakeudev/fakeudev_linux.go
+++ b/pkg/fakeudev/fakeudev_linux.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+package fakeudev
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func sendNetlink(msg []byte) error {
+	fd, err := unix.Socket(unix.AF_NETLINK, unix.SOCK_RAW, unix.NETLINK_KOBJECT_UEVENT)
+	if err != nil {
+		return fmt.Errorf("create netlink socket: %w", err)
+	}
+	defer unix.Close(fd)
+
+	addr := &unix.SockaddrNetlink{Family: unix.AF_NETLINK, Groups: udevEventGroup}
+	if err := unix.Bind(fd, addr); err != nil {
+		return fmt.Errorf("bind netlink socket: %w", err)
+	}
+	if err := unix.Sendto(fd, msg, 0, addr); err != nil {
+		return fmt.Errorf("send netlink message: %w", err)
+	}
+	return nil
+}

--- a/pkg/fakeudev/fakeudev_other.go
+++ b/pkg/fakeudev/fakeudev_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package fakeudev
+
+import "errors"
+
+func sendNetlink(msg []byte) error {
+	return errors.New("fake udev netlink events are only supported on linux")
+}

--- a/pkg/fakeudev/fakeudev_test.go
+++ b/pkg/fakeudev/fakeudev_test.go
@@ -1,0 +1,54 @@
+package fakeudev
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// Reference values computed with wolf's bundled MurmurHash2.cpp
+// (the same implementation libudev/systemd uses for filter hashes).
+func TestMurmurHash2(t *testing.T) {
+	cases := map[string]uint32{
+		"input":  3248653424,
+		"hidraw": 3268080535,
+	}
+	for in, want := range cases {
+		if got := murmurHash2([]byte(in), 0); got != want {
+			t.Errorf("murmurHash2(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestMakeHeader(t *testing.T) {
+	h := makeHeader(100, "input", "")
+	if len(h) != 40 {
+		t.Fatalf("header length = %d, want 40", len(h))
+	}
+	if !bytes.Equal(h[:8], append([]byte("libudev"), 0)) {
+		t.Errorf("prefix = %q", h[:8])
+	}
+	if magic := binary.BigEndian.Uint32(h[8:12]); magic != udevMonitorMagic {
+		t.Errorf("magic = %#x", magic)
+	}
+	if off := binary.LittleEndian.Uint32(h[16:20]); off != 40 {
+		t.Errorf("properties_off = %d", off)
+	}
+	if l := binary.LittleEndian.Uint32(h[20:24]); l != 100 {
+		t.Errorf("properties_len = %d", l)
+	}
+	if sh := binary.BigEndian.Uint32(h[24:28]); sh != 3248653424 {
+		t.Errorf("subsystem hash = %d, want %d", sh, 3248653424)
+	}
+}
+
+func TestEncodeProperties(t *testing.T) {
+	got := encodeProperties(map[string]string{
+		"ACTION":  "add",
+		"DEVNAME": "/dev/input/event3",
+	})
+	want := []byte("ACTION=add\x00DEVNAME=/dev/input/event3\x00")
+	if !bytes.Equal(got, want) {
+		t.Errorf("encodeProperties = %q, want %q", got, want)
+	}
+}

--- a/pkg/generic/controller.go
+++ b/pkg/generic/controller.go
@@ -24,6 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/time/rate"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -106,8 +107,15 @@ func (c *controller[T]) Run(ctx context.Context) error {
 	klog.Infof("starting %s", c.options.Name)
 	defer klog.Infof("stopping %s", c.options.Name)
 
+	// Same shape as workqueue.DefaultTypedControllerRateLimiter, but with the
+	// per-item exponential backoff capped at 5s instead of 1000s. Sessions
+	// only live for ~1 minute before the dead-session reaper collects them,
+	// so retries (e.g. waiting for wolf-agent to come up) must stay frequent.
 	c.queue = workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.DefaultTypedControllerRateLimiter[string](),
+		workqueue.NewTypedMaxOfRateLimiter(
+			workqueue.NewTypedItemExponentialFailureRateLimiter[string](5*time.Millisecond, 5*time.Second),
+			&workqueue.TypedBucketRateLimiter[string]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+		),
 		workqueue.TypedRateLimitingQueueConfig[string]{Name: c.options.Name},
 	)
 

--- a/pkg/moonlight/rest.go
+++ b/pkg/moonlight/rest.go
@@ -503,9 +503,16 @@ func (s *RESTServer) launchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Wait for session to be created by the direwolf controller
+	// Wait for session to be created by the direwolf controller.
+	//
+	// The budget must absorb a cold start of the session pod: image pulls
+	// (multi-GB app images), wolf boot and wolf-agent readiness easily take
+	// 30-60s, while 25s aborted every first launch (the client then cancels
+	// and the half-started session is torn down). The poll is bound to
+	// r.Context(), so if the Moonlight client gives up and disconnects the
+	// wait is cancelled early regardless of this timeout.
 	var streamURL string
-	err = wait.PollUntilContextTimeout(r.Context(), 250*time.Millisecond, 25*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(r.Context(), 250*time.Millisecond, 120*time.Second, true, func(ctx context.Context) (bool, error) {
 		session, err := s.SessionClient.Get(ctx, session.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/pkg/moonlight/rest.go
+++ b/pkg/moonlight/rest.go
@@ -41,6 +41,13 @@ type RESTServerOptions struct {
 	Port       int
 	SecurePort int
 	Cert       tls.Certificate
+
+	// LaunchTimeout is how long /launch will wait for the operator to create a
+	// session and populate its stream URL before giving up. A cold start (image
+	// pull, wolf boot, wolf-agent readiness) can take longer than the default,
+	// so this is exposed as a knob instead of hard-coded. Defaults to 60s if
+	// unset.
+	LaunchTimeout time.Duration
 }
 
 type RESTServer struct {
@@ -70,6 +77,10 @@ func NewRESTServer(
 	sessionClient v1alpha1client.SessionInterface,
 	opts RESTServerOptions,
 ) *RESTServer {
+	if opts.LaunchTimeout <= 0 {
+		opts.LaunchTimeout = 60 * time.Second
+	}
+
 	ps := &RESTServer{
 		router:            http.NewServeMux(),
 		secureRouter:      http.NewServeMux(),
@@ -512,7 +523,7 @@ func (s *RESTServer) launchHandler(w http.ResponseWriter, r *http.Request) {
 	// r.Context(), so if the Moonlight client gives up and disconnects the
 	// wait is cancelled early regardless of this timeout.
 	var streamURL string
-	err = wait.PollUntilContextTimeout(r.Context(), 250*time.Millisecond, 120*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(r.Context(), 250*time.Millisecond, s.LaunchTimeout, true, func(ctx context.Context) (bool, error) {
 		session, err := s.SessionClient.Get(ctx, session.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/pkg/wolfapi/client.go
+++ b/pkg/wolfapi/client.go
@@ -303,9 +303,47 @@ type AppsResponse struct {
 
 type WolfEventType string
 const (
-	PauseStreamEventType WolfEventType = "wolf::core::events::PauseStreamEvent"
+	PauseStreamEventType  WolfEventType = "wolf::core::events::PauseStreamEvent"
+	PlugDeviceEventType   WolfEventType = "wolf::core::events::PlugDeviceEvent"
+	UnplugDeviceEventType WolfEventType = "wolf::core::events::UnplugDeviceEvent"
 )
 
 type PauseStreamEvent struct {
 	SessionID string `json:"session_id"`
+}
+
+// PlugDeviceEvent is fired by wolf when it hotplugs a virtual input device
+// (joypad, mouse, keyboard, ...) for a session. It carries the raw udev
+// event properties and hardware database entries that would normally be
+// delivered by udevd; in the Docker runner wolf injects them into the app
+// container via the fake-udev binary. In Kubernetes the wolf-agent performs
+// the equivalent work (see pkg/fakeudev).
+type PlugDeviceEvent struct {
+	SessionID string `json:"session_id"`
+	// One map of KEY=VALUE udev properties per emitted event.
+	UdevEvents []map[string]string `json:"udev_events"`
+	// Pairs of [filename, lines] to write under /run/udev/data.
+	UdevHwDbEntries []UdevHwDbEntry `json:"udev_hw_db_entries"`
+}
+
+type UnplugDeviceEvent PlugDeviceEvent
+
+// UdevHwDbEntry decodes wolf's [name, [lines...]] JSON tuples.
+type UdevHwDbEntry struct {
+	Filename string
+	Content  []string
+}
+
+func (e *UdevHwDbEntry) UnmarshalJSON(data []byte) error {
+	var raw []json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if len(raw) != 2 {
+		return fmt.Errorf("expected [filename, lines] tuple, got %d elements", len(raw))
+	}
+	if err := json.Unmarshal(raw[0], &e.Filename); err != nil {
+		return err
+	}
+	return json.Unmarshal(raw[1], &e.Content)
 }


### PR DESCRIPTION
## Problem

`launchHandler` waits for the direwolf controller to create the session before returning the stream URL, but the poll budget is only 25s:

```go
err = wait.PollUntilContextTimeout(r.Context(), 250*time.Millisecond, 25*time.Second, true, func(ctx context.Context) (bool, error) {
    session, err := s.SessionClient.Get(ctx, session.Name, metav1.GetOptions{})
    ...
})
```

A cold session start routinely exceeds that: pulling a multi-GB app image, booting Wolf, and waiting for `wolf-agent` readiness easily takes 30–60s. When the 25s budget runs out, `/launch` returns 500 right before the pod becomes ready; the Moonlight client then cancels and the half-started session is torn down. In practice the first launch of an app fails almost every time.

## Fix

* Raise the `/launch` poll budget from 25s to **120s**.

The poll is bound to `r.Context()`, so if the Moonlight client gives up and disconnects the wait is still cancelled early — the larger timeout only extends the patient path, it does not hold anything open after the client has left.

## Testing

* `go build ./...` and `go test ./pkg/moonlight/...` pass.
* On my Talos cluster (RTX 5090, fenrir/wolf), cold starts that previously returned 500 at the 25s mark now complete on the first launch. Engineering notes: https://github.com/shrinedogg/biggs.dog#patched-fork--engineering-notes
