### PR TITLE
[wolf-agent] act as fake-udev for hotplugged input devices

### DIFF
--- a/pkg/controllers/agent.go
+++ b/pkg/controllers/agent.go
@@ -5,10 +5,16 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"games-on-whales.github.io/direwolf/pkg/fakeudev"
 	"games-on-whales.github.io/direwolf/pkg/wolfapi"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
 )
+
+// UdevDataPath is where udev database entries are written for hotplugged
+// devices. It must be a volume shared with the app container (mounted at
+// /run/udev there) for libudev consumers (SDL/Steam) to see them.
+const UdevDataPath = "/run/udev/data"
 
 // Represents the controller that runs inside the Pod itself
 type Agent struct {
@@ -73,6 +79,24 @@ func (a *Agent) watchEvents(ctx context.Context) error {
 						utilruntime.HandleError(fmt.Errorf("failed to stop session: %w", err))
 						continue
 					}
+				// Wolf hotplugged a virtual input device. Play the role of
+				// fake-udev: publish the udev db entry and broadcast a
+				// synthetic udev netlink event in the pod's network
+				// namespace so the app container's SDL/Steam notices it.
+				case wolfapi.PlugDeviceEventType:
+					var plugEvent wolfapi.PlugDeviceEvent
+					if err := json.Unmarshal(ev.Data, &plugEvent); err != nil {
+						utilruntime.HandleError(fmt.Errorf("failed to unmarshal plug device event: %w", err))
+						continue
+					}
+					a.handleDevicePlug(plugEvent)
+				case wolfapi.UnplugDeviceEventType:
+					var unplugEvent wolfapi.UnplugDeviceEvent
+					if err := json.Unmarshal(ev.Data, &unplugEvent); err != nil {
+						utilruntime.HandleError(fmt.Errorf("failed to unmarshal unplug device event: %w", err))
+						continue
+					}
+					a.handleDeviceUnplug(unplugEvent)
 				default:
 					continue
 				}
@@ -81,4 +105,64 @@ func (a *Agent) watchEvents(ctx context.Context) error {
 	}()
 
 	return nil
+}
+
+func (a *Agent) handleDevicePlug(ev wolfapi.PlugDeviceEvent) {
+	// Wolf reports MAJOR/MINOR as "0" when it cannot stat the device node
+	// in its own container; resolve the real numbers from sysfs so both
+	// the netlink event and the hwdb filename are correct.
+	for _, udevEvent := range ev.UdevEvents {
+		fakeudev.ResolveDevNumbers(udevEvent)
+	}
+
+	for _, entry := range ev.UdevHwDbEntries {
+		filename := entry.Filename
+		// Recompute "cMAJOR:MINOR" filenames that were built from the
+		// zeroed-out device numbers.
+		if filename == "c0:0" && len(ev.UdevEvents) > 0 {
+			if maj := ev.UdevEvents[0]["MAJOR"]; maj != "" && maj != "0" {
+				filename = "c" + maj + ":" + ev.UdevEvents[0]["MINOR"]
+			}
+		}
+		if err := fakeudev.WriteHwDbEntry(UdevDataPath, filename, entry.Content); err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to write udev hwdb entry %q: %w", filename, err))
+		} else {
+			klog.InfoS("Wrote udev hwdb entry", "file", filename, "session", ev.SessionID)
+		}
+	}
+
+	for _, udevEvent := range ev.UdevEvents {
+		if err := fakeudev.SendEvent(udevEvent); err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to send udev event for %q: %w", udevEvent["DEVNAME"], err))
+		} else {
+			klog.InfoS("Sent fake udev event", "action", udevEvent["ACTION"], "devname", udevEvent["DEVNAME"], "session", ev.SessionID)
+		}
+	}
+}
+
+func (a *Agent) handleDeviceUnplug(ev wolfapi.UnplugDeviceEvent) {
+	for _, udevEvent := range ev.UdevEvents {
+		fakeudev.ResolveDevNumbers(udevEvent)
+	}
+
+	for _, entry := range ev.UdevHwDbEntries {
+		filename := entry.Filename
+		if filename == "c0:0" && len(ev.UdevEvents) > 0 {
+			if maj := ev.UdevEvents[0]["MAJOR"]; maj != "" && maj != "0" {
+				filename = "c" + maj + ":" + ev.UdevEvents[0]["MINOR"]
+			}
+		}
+		if err := fakeudev.RemoveHwDbEntry(UdevDataPath, filename); err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to remove udev hwdb entry %q: %w", filename, err))
+		}
+	}
+
+	for _, udevEvent := range ev.UdevEvents {
+		udevEvent["ACTION"] = "remove"
+		if err := fakeudev.SendEvent(udevEvent); err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to send udev remove event for %q: %w", udevEvent["DEVNAME"], err))
+		} else {
+			klog.InfoS("Sent fake udev remove event", "devname", udevEvent["DEVNAME"], "session", ev.SessionID)
+		}
+	}
 }

--- a/pkg/fakeudev/fakeudev.go
+++ b/pkg/fakeudev/fakeudev.go
@@ -1,0 +1,173 @@
+// Package fakeudev replicates wolf's fake-udev mechanism in Go.
+//
+// Wolf creates virtual input devices (joypads, mice, keyboards) through
+// /dev/uinput. The kernel emits the corresponding uevents only in the
+// initial network namespace, so processes inside the session pod never
+// hear about them, and libudev consumers (SDL, Steam) ignore devices
+// that have no entry in the udev database (/run/udev/data).
+//
+// In wolf's Docker runner this is solved by exec'ing the `fake-udev` C
+// binary inside the app container, which:
+//  1. writes the udev hwdb entries under /run/udev/data, and
+//  2. broadcasts a synthetic "libudev" netlink message to the udev
+//     multicast group (2) inside the container's network namespace.
+//
+// Containers in a Kubernetes pod share their network namespace, so the
+// wolf-agent sidecar can do both jobs for the app container, provided
+// /run/udev is a volume shared between the agent and app containers.
+//
+// Wire format reference:
+// https://github.com/systemd/systemd/blob/main/src/libsystemd/sd-device/device-monitor.c
+// and wolf's src/fake-udev.
+package fakeudev
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	udevMonitorMagic = 0xfeedcafe
+	// Multicast group used by udevd -> libudev listeners ("udev" source).
+	udevEventGroup = 2
+)
+
+// murmurHash2 is the classic (non-A) MurmurHash2 used by
+// systemd/libudev for filter_subsystem_hash (util_string_hash32).
+func murmurHash2(data []byte, seed uint32) uint32 {
+	const m = 0x5bd1e995
+	const r = 24
+
+	h := seed ^ uint32(len(data))
+	for len(data) >= 4 {
+		k := binary.LittleEndian.Uint32(data)
+		k *= m
+		k ^= k >> r
+		k *= m
+		h *= m
+		h ^= k
+		data = data[4:]
+	}
+	switch len(data) {
+	case 3:
+		h ^= uint32(data[2]) << 16
+		fallthrough
+	case 2:
+		h ^= uint32(data[1]) << 8
+		fallthrough
+	case 1:
+		h ^= uint32(data[0])
+		h *= m
+	}
+	h ^= h >> 13
+	h *= m
+	h ^= h >> 15
+	return h
+}
+
+// header mirrors systemd's monitor_netlink_header (40 bytes).
+func makeHeader(propertiesLen int, subsystem, devtype string) []byte {
+	buf := &bytes.Buffer{}
+	buf.WriteString("libudev")
+	buf.WriteByte(0)
+	// magic is stored in network byte order
+	_ = binary.Write(buf, binary.BigEndian, uint32(udevMonitorMagic))
+	// sizes/offsets are native endian (x86_64: little endian)
+	_ = binary.Write(buf, binary.LittleEndian, uint32(40)) // header_size
+	_ = binary.Write(buf, binary.LittleEndian, uint32(40)) // properties_off
+	_ = binary.Write(buf, binary.LittleEndian, uint32(propertiesLen))
+	var subsystemHash, devtypeHash uint32
+	if subsystem != "" {
+		subsystemHash = murmurHash2([]byte(subsystem), 0)
+	}
+	if devtype != "" {
+		devtypeHash = murmurHash2([]byte(devtype), 0)
+	}
+	// filter hashes are stored in network byte order
+	_ = binary.Write(buf, binary.BigEndian, subsystemHash)
+	_ = binary.Write(buf, binary.BigEndian, devtypeHash)
+	_ = binary.Write(buf, binary.LittleEndian, uint32(0)) // filter_tag_bloom_hi
+	_ = binary.Write(buf, binary.LittleEndian, uint32(0)) // filter_tag_bloom_lo
+	return buf.Bytes()
+}
+
+// encodeProperties serializes the udev properties as NUL-separated
+// KEY=VALUE pairs, ACTION first (mirrors wolf's std::map ordering, which
+// is alphabetical; ACTION happens to sort first anyway).
+func encodeProperties(props map[string]string) []byte {
+	keys := make([]string, 0, len(props))
+	for k := range props {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	buf := &bytes.Buffer{}
+	for _, k := range keys {
+		buf.WriteString(k)
+		buf.WriteByte('=')
+		buf.WriteString(props[k])
+		buf.WriteByte(0)
+	}
+	return buf.Bytes()
+}
+
+// SendEvent broadcasts a synthetic libudev netlink event in the current
+// network namespace. Requires CAP_NET_ADMIN. See fakeudev_linux.go.
+func SendEvent(props map[string]string) error {
+	subsystem := props["SUBSYSTEM"]
+	if subsystem == "" {
+		subsystem = "input"
+	}
+	payload := encodeProperties(props)
+	msg := append(makeHeader(len(payload), subsystem, props["DEVTYPE"]), payload...)
+	return sendNetlink(msg)
+}
+
+// WriteHwDbEntry writes a udev database entry (e.g. "c13:67") under
+// baseDir (normally /run/udev/data) so libudev enumeration picks up the
+// device properties (ID_INPUT_JOYSTICK etc.).
+func WriteHwDbEntry(baseDir, filename string, content []string) error {
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		return err
+	}
+	path := filepath.Join(baseDir, filepath.Base(filename))
+	return os.WriteFile(path, []byte(strings.Join(content, "\n")), 0o644)
+}
+
+// RemoveHwDbEntry deletes a previously written udev database entry.
+func RemoveHwDbEntry(baseDir, filename string) error {
+	err := os.Remove(filepath.Join(baseDir, filepath.Base(filename)))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// ResolveDevNumbers fills in MAJOR/MINOR from sysfs when wolf could not
+// stat the device node itself (it reports "0"/"0" in that case, because
+// /dev/input is not mounted in the wolf container). DEVPATH is always
+// present and sysfs is readable from any container.
+func ResolveDevNumbers(props map[string]string) (major, minor string) {
+	major, minor = props["MAJOR"], props["MINOR"]
+	if major != "" && major != "0" {
+		return major, minor
+	}
+	devpath := props["DEVPATH"]
+	if devpath == "" {
+		return major, minor
+	}
+	data, err := os.ReadFile(filepath.Join("/sys", devpath, "dev"))
+	if err != nil {
+		return major, minor
+	}
+	parts := strings.SplitN(strings.TrimSpace(string(data)), ":", 2)
+	if len(parts) != 2 {
+		return major, minor
+	}
+	props["MAJOR"], props["MINOR"] = parts[0], parts[1]
+	return parts[0], parts[1]
+}

--- a/pkg/fakeudev/fakeudev_linux.go
+++ b/pkg/fakeudev/fakeudev_linux.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+package fakeudev
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func sendNetlink(msg []byte) error {
+	fd, err := unix.Socket(unix.AF_NETLINK, unix.SOCK_RAW, unix.NETLINK_KOBJECT_UEVENT)
+	if err != nil {
+		return fmt.Errorf("create netlink socket: %w", err)
+	}
+	defer unix.Close(fd)
+
+	addr := &unix.SockaddrNetlink{Family: unix.AF_NETLINK, Groups: udevEventGroup}
+	if err := unix.Bind(fd, addr); err != nil {
+		return fmt.Errorf("bind netlink socket: %w", err)
+	}
+	if err := unix.Sendto(fd, msg, 0, addr); err != nil {
+		return fmt.Errorf("send netlink message: %w", err)
+	}
+	return nil
+}

--- a/pkg/fakeudev/fakeudev_other.go
+++ b/pkg/fakeudev/fakeudev_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package fakeudev
+
+import "errors"
+
+func sendNetlink(msg []byte) error {
+	return errors.New("fake udev netlink events are only supported on linux")
+}

--- a/pkg/fakeudev/fakeudev_test.go
+++ b/pkg/fakeudev/fakeudev_test.go
@@ -1,0 +1,54 @@
+package fakeudev
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+// Reference values computed with wolf's bundled MurmurHash2.cpp
+// (the same implementation libudev/systemd uses for filter hashes).
+func TestMurmurHash2(t *testing.T) {
+	cases := map[string]uint32{
+		"input":  3248653424,
+		"hidraw": 3268080535,
+	}
+	for in, want := range cases {
+		if got := murmurHash2([]byte(in), 0); got != want {
+			t.Errorf("murmurHash2(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestMakeHeader(t *testing.T) {
+	h := makeHeader(100, "input", "")
+	if len(h) != 40 {
+		t.Fatalf("header length = %d, want 40", len(h))
+	}
+	if !bytes.Equal(h[:8], append([]byte("libudev"), 0)) {
+		t.Errorf("prefix = %q", h[:8])
+	}
+	if magic := binary.BigEndian.Uint32(h[8:12]); magic != udevMonitorMagic {
+		t.Errorf("magic = %#x", magic)
+	}
+	if off := binary.LittleEndian.Uint32(h[16:20]); off != 40 {
+		t.Errorf("properties_off = %d", off)
+	}
+	if l := binary.LittleEndian.Uint32(h[20:24]); l != 100 {
+		t.Errorf("properties_len = %d", l)
+	}
+	if sh := binary.BigEndian.Uint32(h[24:28]); sh != 3248653424 {
+		t.Errorf("subsystem hash = %d, want %d", sh, 3248653424)
+	}
+}
+
+func TestEncodeProperties(t *testing.T) {
+	got := encodeProperties(map[string]string{
+		"ACTION":  "add",
+		"DEVNAME": "/dev/input/event3",
+	})
+	want := []byte("ACTION=add\x00DEVNAME=/dev/input/event3\x00")
+	if !bytes.Equal(got, want) {
+		t.Errorf("encodeProperties = %q, want %q", got, want)
+	}
+}

--- a/pkg/wolfapi/client.go
+++ b/pkg/wolfapi/client.go
@@ -303,9 +303,47 @@ type AppsResponse struct {
 
 type WolfEventType string
 const (
-	PauseStreamEventType WolfEventType = "wolf::core::events::PauseStreamEvent"
+	PauseStreamEventType  WolfEventType = "wolf::core::events::PauseStreamEvent"
+	PlugDeviceEventType   WolfEventType = "wolf::core::events::PlugDeviceEvent"
+	UnplugDeviceEventType WolfEventType = "wolf::core::events::UnplugDeviceEvent"
 )
 
 type PauseStreamEvent struct {
 	SessionID string `json:"session_id"`
+}
+
+// PlugDeviceEvent is fired by wolf when it hotplugs a virtual input device
+// (joypad, mouse, keyboard, ...) for a session. It carries the raw udev
+// event properties and hardware database entries that would normally be
+// delivered by udevd; in the Docker runner wolf injects them into the app
+// container via the fake-udev binary. In Kubernetes the wolf-agent performs
+// the equivalent work (see pkg/fakeudev).
+type PlugDeviceEvent struct {
+	SessionID string `json:"session_id"`
+	// One map of KEY=VALUE udev properties per emitted event.
+	UdevEvents []map[string]string `json:"udev_events"`
+	// Pairs of [filename, lines] to write under /run/udev/data.
+	UdevHwDbEntries []UdevHwDbEntry `json:"udev_hw_db_entries"`
+}
+
+type UnplugDeviceEvent PlugDeviceEvent
+
+// UdevHwDbEntry decodes wolf's [name, [lines...]] JSON tuples.
+type UdevHwDbEntry struct {
+	Filename string
+	Content  []string
+}
+
+func (e *UdevHwDbEntry) UnmarshalJSON(data []byte) error {
+	var raw []json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if len(raw) != 2 {
+		return fmt.Errorf("expected [filename, lines] tuple, got %d elements", len(raw))
+	}
+	if err := json.Unmarshal(raw[0], &e.Filename); err != nil {
+		return err
+	}
+	return json.Unmarshal(raw[1], &e.Content)
 }


### PR DESCRIPTION
## Problem

Wolf creates virtual input devices (gamepads, mouse, keyboard) at runtime and publishes `PlugDeviceEvent` / `UnplugDeviceEvent` over its API, carrying the raw udev properties and hwdb entries for each device. In the Docker runner, Wolf's `fake-udev` helper consumes those events and injects the matching udev database entry plus a libudev netlink event, so that SDL/Steam inside the container actually detect the device.

Under Kubernetes (direwolf), nothing performs that fake-udev injection. The kernel only broadcasts real uevents in the host network namespace, so a device hotplugged by Wolf is invisible to clients in the session pod — controllers never show up in-game.

## Fix

Implement the fake-udev role in `wolf-agent`:

* Subscribe to Wolf's device plug/unplug events (`pkg/wolfapi`).
* On plug, write the `/run/udev/data/` entry to a volume shared with the app container, and broadcast a synthetic libudev netlink event inside the pod network namespace so `libudev` clients (SDL/Steam) discover the device.
* Resolve `MAJOR`/`MINOR` from sysfs, since Wolf cannot `stat` `/dev/input` from its own container.
* Remove the entry again on unplug.

This adds a new `pkg/fakeudev` package (with unit tests) and wires it into `pkg/controllers/agent.go`.

> Deployment note: broadcasting libudev netlink events requires `CAP_NET_ADMIN` in the pod netns, and the agent and app containers must share the udev-data volume. Cluster-side wiring is documented at the link below.

## Testing

* `go build ./...` (native and `GOOS=linux GOARCH=amd64`) and `go test ./pkg/fakeudev/...` pass.
* Running on my Talos cluster (RTX 5090, fenrir/wolf): Steam/SDL now detect the Moonlight controller in-game, where previously no controller appeared. Engineering notes / full context: https://github.com/shrinedogg/biggs.dog#patched-fork--engineering-notes
