### PR TITLE
Fix malformed json struct tag on RuntimeWolfVariables.RenderNode

### DIFF
--- a/pkg/api/v1alpha1/app.go
+++ b/pkg/api/v1alpha1/app.go
@@ -64,7 +64,7 @@ type RuntimeWolfVariables struct {
 	// Wolf defaults to: "/dev/dri/renderD128"
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default="/dev/dri/renderD128"
-	RenderNode string `json:"renderNode,omitempty""`
+	RenderNode string `json:"renderNode,omitempty"`
 	
 	// Time zone for the wolf container
 	// +kubebuilder:validation:Optional


### PR DESCRIPTION
## Problem

The `RenderNode` field on `RuntimeWolfVariables` has a malformed struct tag — there's a stray trailing double quote:

```go
RenderNode string `json:"renderNode,omitempty""`
```

`go vet` flags it:

```
pkg/api/v1alpha1/app.go:67:2: struct field tag `json:"renderNode,omitempty""` not compatible with reflect.StructTag.Get: key:"value" pairs not separated by spaces
```

Because `reflect.StructTag.Get` cannot parse the tag, any tag lookup for this field is unreliable, and `go vet` fails (breaking `vet`-gated CI).

## Fix

* Drop the extra quote: `json:"renderNode,omitempty"`.

## Testing

* `go vet ./pkg/api/v1alpha1/` is now clean and the package builds.
